### PR TITLE
Restore Affinity as an active connector

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,6 +16,11 @@
 
 ## Connectors
 
+- [Affinity](connectors/affinity/README.md)
+  - [Authorize Affinity](connectors/affinity/authorize-affinity.md)
+  - [Full records vs. shallow records](connectors/affinity/full-records-vs.-shallow-records.md)
+  - [List-specific fields](connectors/affinity/list-specific-fields.md)
+  - [Notes in Affinity](connectors/affinity/notes-in-affinity.md)
 - [Airtable](connectors/airtable/README.md)
   - [Airtable view sync](connectors/airtable/airtable-view-sync.md)
   - [Airtable API quota](connectors/airtable/airtable-api-quota.md)
@@ -77,11 +82,6 @@
 ---
 
 - [Previous connectors](previous-connectors/README.md)
-  - [Affinity](previous-connectors/affinity/README.md)
-    - [Authorize Affinity](previous-connectors/affinity/authorize-affinity.md)
-    - [Full records vs. shallow records](previous-connectors/affinity/full-records-vs.-shallow-records.md)
-    - [List-specific fields](previous-connectors/affinity/list-specific-fields.md)
-    - [Notes in Affinity](previous-connectors/affinity/notes-in-affinity.md)
   - [Attio](previous-connectors/attio.md)
   - [Bubble](previous-connectors/bubble/README.md)
     - [Authorize Bubble](previous-connectors/bubble/authorize-bubble.md)

--- a/connectors/affinity/README.md
+++ b/connectors/affinity/README.md
@@ -3,10 +3,6 @@ cover: ../../.gitbook/assets/gitbook-cover_affinity.jpg
 coverY: 0
 ---
 
-{% hint style="warning" %}
-**Archived:** This connector is no longer offered by Whalesync. Existing syncs will continue to run, but future improvements and support will be limited. See [Previous Connectors](../) for more details.
-{% endhint %}
-
 # Affinity
 
 ## Supported Tables

--- a/connectors/affinity/authorize-affinity.md
+++ b/connectors/affinity/authorize-affinity.md
@@ -2,10 +2,6 @@
 description: How to get your Affinity API key
 ---
 
-{% hint style="warning" %}
-**Archived:** This connector is no longer offered by Whalesync. Existing syncs will continue to run, but future improvements and support will be limited. See [Previous Connectors](../) for more details.
-{% endhint %}
-
 # Authorize Affinity
 
 **1) Click "Settings"**

--- a/connectors/affinity/full-records-vs.-shallow-records.md
+++ b/connectors/affinity/full-records-vs.-shallow-records.md
@@ -2,10 +2,6 @@
 description: Understanding what a "shallow record" is in Affinity
 ---
 
-{% hint style="warning" %}
-**Archived:** This connector is no longer offered by Whalesync. Existing syncs will continue to run, but future improvements and support will be limited. See [Previous Connectors](../) for more details.
-{% endhint %}
-
 # Full records vs. shallow records
 
 Unless you are on Affinity's Enterprise plan, Affinity has significant API limitations which limits our ability to sync all records. To work around this, Whalesync groups your records into two categories:

--- a/connectors/affinity/list-specific-fields.md
+++ b/connectors/affinity/list-specific-fields.md
@@ -2,10 +2,6 @@
 description: How to sync list-specific fields in Affinity
 ---
 
-{% hint style="warning" %}
-**Archived:** This connector is no longer offered by Whalesync. Existing syncs will continue to run, but future improvements and support will be limited. See [Previous Connectors](../) for more details.
-{% endhint %}
-
 # List-specific fields
 
 Affinity lets you add list-specific fields that only appear on specific lists:

--- a/connectors/affinity/notes-in-affinity.md
+++ b/connectors/affinity/notes-in-affinity.md
@@ -2,10 +2,6 @@
 description: Things to be aware of when syncing Affinity notes
 ---
 
-{% hint style="warning" %}
-**Archived:** This connector is no longer offered by Whalesync. Existing syncs will continue to run, but future improvements and support will be limited. See [Previous Connectors](../) for more details.
-{% endhint %}
-
 # Notes in Affinity
 
 ### Creating vs. editing

--- a/previous-connectors/README.md
+++ b/previous-connectors/README.md
@@ -30,7 +30,6 @@ Just reach out to [support@whalesync.com](mailto:support@whalesync.com) and we'l
 
 # Previous connectors
 
-- [Affinity](affinity/)
 - [Attio](attio.md)
 - [Bubble](bubble/)
 - [Close](close.md)


### PR DESCRIPTION
Moves Affinity out of "Previous connectors" back into the main Connectors list and removes the archived warning hints from each Affinity page.