### PR TITLE
Document monthly-active record counting and limits

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -146,6 +146,7 @@
   - [Common errors - Webflow](resources/support/common-errors-webflow.md)
   - [Reconnecting a sync](resources/support/reconnecting-a-sync.md)
   - [FAQ](resources/support/faq.md)
+  - [How record limits work](resources/support/how-record-limits-work.md)
   - [Field compatibility](resources/support/field-compatibility.md)
   - [How to get record IDs](resources/support/how-to-get-record-ids.md)
   - [How to change your sign-in](resources/support/how-to-change-your-sign-in.md)

--- a/features/additional-features/selective-sync.md
+++ b/features/additional-features/selective-sync.md
@@ -59,9 +59,9 @@ No. The control field should only exist on the side you want to control from and
 
 Changes are ignored while paused. When you re-enable syncing, edits made in either app will sync. If the same field was edited in both apps, the most recent change wins.
 
-### Will the records still count toward my limits if they are paused?
+### Will the records still count toward my record limit if they are paused?
 
-Yes. Selective sync is intended for temporarily pausing the syncing on a record while you edit it. The record still counts toward quota.
+Yes. Selective row-level sync pauses an individual record, not the whole sync — the sync is still active, so the record still counts toward your record limit. (Pausing or deleting an _entire_ sync is what changes your count — see [How record limits work](../../resources/support/how-record-limits-work.md).)
 
 ### Can I use filters with selective row-level sync?
 

--- a/live-export/README.md
+++ b/live-export/README.md
@@ -97,7 +97,7 @@ They're removed from the copy too, so the destination stays a true mirror. Rows 
 
 <summary>Does Live Export count against my plan's record limit?</summary>
 
-Yes, **Live Export** records count toward the same plan quota.
+Yes — **Live Export** records count toward your plan's record limit just like your other syncs. See [How record limits work](../resources/support/how-record-limits-work.md) for how counting works.
 
 </details>
 

--- a/resources/support/faq.md
+++ b/resources/support/faq.md
@@ -14,7 +14,7 @@ For a more detailed breakdown, check out: [How is Whalesync different from Zapie
 
 ## How does Whalesync count records?
 
-Whalesync only counts the records that you keep in sync and we don't "double-count" records across a Whalesync base.\
+Whalesync counts the records in your **active syncs** — syncs that have run at any point during the current calendar month — and we don't "double-count" records across a Whalesync base.\
 \
 For example, let's say you have two Airtable bases:
 
@@ -28,7 +28,11 @@ Then you use Whalesync to sync Base 1 and Base 2, so now each has:
 
 In total Whalesync would count that as 100 records.\
 \
-If you have other Airtable bases in your account (e.g. Base 3, Base 4, etc.). None of those would count towards your Whalesync total until you start syncing them.
+If you have other Airtable bases in your account (e.g. Base 3, Base 4, etc.), none of those count towards your Whalesync total until you start syncing them.
+
+**Paused syncs don't count against your limit.** If a sync stays paused for a full calendar month, its records stop counting the next month, and deleting a sync removes its records from your count right away. Your count resets at the start of each month, so it always reflects what you're actively syncing.
+
+For a full breakdown, see [How record limits work](how-record-limits-work.md).
 
 ## What data does Whalesync store?
 
@@ -48,3 +52,5 @@ As an example, for Airtable, Whalesync stores your records, your Airtable base I
 Yes, if you pause your subscription, syncing will be disabled but Whalesync will not delete your sync configurations.
 
 If you reactivate your subscription in the future, you will be able to resume your syncs and all pending changes will be synced over.
+
+Because your syncs are disabled while your subscription is paused, they stop counting toward your record limit the following calendar month. See [How record limits work](how-record-limits-work.md) for more on how record counting works.

--- a/resources/support/how-record-limits-work.md
+++ b/resources/support/how-record-limits-work.md
@@ -1,0 +1,52 @@
+---
+description: >-
+  How Whalesync counts records against your record limit, how to manage your
+  usage, and what happens if you go over.
+---
+
+# How record limits work
+
+Every Whalesync plan includes a limit on the number of records you can keep in sync. This page explains how that count works, how to manage it, and what happens if you go over your limit.
+
+## What counts toward your limit
+
+Whalesync counts the records in your **active syncs** — syncs that have run at any point during the current calendar month.
+
+A few things follow from this:
+
+* **We don't double-count.** When the same records are kept in sync across the two sides of a Whalesync base, they're counted once, not twice. (See [How does Whalesync count records?](faq.md#how-does-whalesync-count-records) for a worked example.)
+* **Records you aren't syncing don't count.** Bases, tables, or apps you've connected but haven't started syncing don't count toward your limit until they're syncing.
+* **Paused syncs stop counting.** A sync that stays paused for an entire calendar month no longer counts the following month.
+
+## The monthly reset
+
+Your record count is based on a calendar month and resets at the start of each new month. Each month, only the syncs that were active _that_ month count toward your limit.
+
+* A sync you keep running counts every month.
+* A sync you leave paused for a full month drops out of your count the next month.
+* A sync that was active for even part of a month counts for that whole month. (Pausing a sync at the very end of the month won't lower your count for that month — it still counted while it was on.)
+
+## Freeing up room
+
+There are two ways to reduce your record count:
+
+* **Pause a sync** and its records stop counting **starting next month**. Choose this if you might want to turn the sync back on later — your configuration is kept, and you can resume anytime.
+* **Delete a sync** and its records come off your count **immediately**. Choose this if you want relief in the current month and no longer need the sync.
+
+You can also **upgrade your plan** at any time for a higher record limit.
+
+## What happens if you go over your limit
+
+If your synced records exceed your plan's limit, Whalesync will email you to let you know. You'll have time to get back under your limit — by pausing or deleting syncs you no longer need, or by upgrading your plan — before anything changes about your syncs.
+
+If you're still over your limit after a series of reminder emails, Whalesync will pause your syncs. Your sync configurations are never deleted — once you're back under your limit or you've upgraded, you can re-enable your syncs from your dashboard.
+
+## Getting back under your limit
+
+To bring your usage back under your limit:
+
+1. **See which syncs are using the most records.** Each sync's settings page shows how many records it's using, and a sync that isn't counting toward your limit this month is marked **Dormant**.
+2. **Pause syncs you don't need right now** to free up room next month, or **delete** them to free up room immediately.
+3. **Or upgrade your plan** for more headroom right away.
+
+If your syncs were already paused by Whalesync, re-enable them from your dashboard once you're back under your limit.


### PR DESCRIPTION
Record counting is changing from "every sync you've ever set up" to monthly-active records — only syncs active in the current calendar month count toward a plan's record limit, resetting on the 1st.

- Add a new "How record limits work" support page covering what counts, the monthly reset, freeing up room (pause vs delete vs upgrade), and what happens if you go over your limit
- Rewrite the FAQ "How does Whalesync count records?" answer and update the "If I pause my subscription…" answer for the new model
- Clarify selective row-level sync vs pausing a whole sync in the FAQ
- Note Live Export records follow the same counting rules
- Normalize "quota"/"plan quota" wording to "record limit" (leaving third-party API quotas untouched)
- Add the new page to the Support nav in SUMMARY.md
