### PR TITLE
Add Live Export vs. sync comparison page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -136,6 +136,7 @@
 ## Live Export
 
 * [Live Export](live-export/live-export.md)
+  * [Live Export vs. sync](live-export/live-export-vs-sync.md)
 
 ## Resources
 

--- a/live-export/README.md
+++ b/live-export/README.md
@@ -9,7 +9,7 @@ description: Keep a live, updated copy of your data in another tool
 Unlike a standard Whalesync sync, **Live Export** is one-way and read-only: your source stays the system of record, while **Live Export** mirrors that data to a destination of your choice, and keeps it up-to-date as your source changes.
 
 {% hint style="info" %}
-**Live Export** is separate from Whalesync's standard two-way sync. It's built for making a clean, read-only copy of your data rather than keeping two apps in sync.
+**Live Export** is separate from Whalesync's standard two-way sync. It's built for making a clean, read-only copy of your data rather than keeping two apps in sync. See [Live Export vs. sync](live-export-vs-sync.md) for a full comparison.
 {% endhint %}
 
 {% embed url="https://www.loom.com/share/07cf25f5b2ee40ebb187d475d7007d89" %}

--- a/live-export/live-export-vs-sync.md
+++ b/live-export/live-export-vs-sync.md
@@ -1,0 +1,48 @@
+---
+description: When to use Live Export and when to use a standard Whalesync sync
+---
+
+# Live Export vs. sync
+
+Whalesync offers two ways to move your data, built for different jobs:
+
+- A **Sync** **keeps two apps in sync**. Both stay live and up to date, and you can edit data in either one. More powerful and configurable.
+- **Live Export** makes a **read-only copy** of your data in another tool. You view, query, or share it, but don't edit it. Simpler and quicker to set up.
+
+## Sample uses
+
+{% hint style="success" %}
+**Sync**: two apps stay in step, and you edit data in both.
+
+- Control your Webflow site from Airtable.
+- Update your HubSpot deals status from Notion.
+- Let an operator edit your Supabase database from a friendly Airtable interface.
+{% endhint %}
+
+{% hint style="info" %}
+**Live Export**: a read-only copy for viewing, sharing, or analysis.
+
+- Analyze your Shopify orders in Notion.
+- Share a subset of your Hubspot fields with a teammate in Airtable.
+- Keep a queryable backup of your production data in Supabase.
+{% endhint %}
+
+## At a glance
+
+|                        | Sync                                          | Live Export                                        |
+| ---------------------- | --------------------------------------------- | -------------------------------------------------- |
+| **Main purpose**       | Keep two apps in sync                         | Read-only copy of your data in another tool        |
+| **Complexity**         | More powerful and configurable                | Simpler and quicker to set up                      |
+| **Direction**          | One-way or [two-way](../features/two-way-sync.md) | One-way only                                   |
+| **Destination**        | Editable — two-way sends your edits back      | Read-only mirror, overwritten on each run          |
+| **Updates**            | Real time, as data changes                    | On demand or on a schedule                         |
+| **Destination tables** | Existing tables or newly created tables       | Newly created for you                              |
+| **Apps**               | Any connected app, on either side             | From any app, into Airtable, Notion, or Supabase   |
+
+A few of these deserve a note:
+
+- **Edits in a Live Export destination don't stick.** They aren't sent back to your source, and each run overwrites them. If you need edits to flow back, use a two-way sync.
+- **Live Export builds the destination for you.** It creates the tables and fields in the base, schema, or page you choose. To write into tables you already maintain, use a sync.
+- **Live Export destinations are Airtable, Notion, and Supabase.** You can export *from* any connected app; see what's available [here](https://app.whalesync.com/exports/setup/new/connect).
+
+Still unsure? [Reach out](../resources/support/README.md) and we'll help you pick.

--- a/live-export/live-export.md
+++ b/live-export/live-export.md
@@ -9,7 +9,7 @@ description: Keep a live, updated copy of your data in another tool
 Unlike a standard Whalesync sync, **Live Export** is one-way and read-only: your source stays the system of record, while **Live Export** mirrors that data to a destination of your choice, and keeps it up-to-date as your source changes.
 
 {% hint style="info" %}
-**Live Export** is separate from Whalesync's standard two-way sync. It's built for making a clean, read-only copy of your data rather than keeping two apps in sync.
+**Live Export** is separate from Whalesync's standard two-way sync. It's built for making a clean, read-only copy of your data rather than keeping two apps in sync. See [Live Export vs. sync](live-export-vs-sync.md) for a full comparison.
 {% endhint %}
 
 {% embed url="https://www.loom.com/share/07cf25f5b2ee40ebb187d475d7007d89" %}


### PR DESCRIPTION
## Summary

People are confused about the difference between Live Export and a standard sync. This adds a comparison page under the Live Export section.

- New page `live-export/live-export-vs-sync.md`: core distinction up front (keep two apps in sync vs. read-only copy), featured sample uses in callouts, and an at-a-glance table covering direction, editability, updates, destination tables, and supported apps.
- Linked from the info callout on the Live Export page (both `live-export.md` and its duplicate `README.md`).
- Added to `SUMMARY.md` nested under Live Export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)